### PR TITLE
Add notebook and report for hybrid quantum-classical forecasting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# Time-Series-Forecasting-Using-Hybrid-Quantum-Classical-Models
+# Time-Series Forecasting Using Hybrid Quantum-Classical Models
+
+This repository contains resources for experimenting with hybrid quantum-classical neural networks on time series forecasting tasks. The project couples a classical LSTM with a variational quantum circuit and compares its performance with a purely classical baseline.
+
+## Contents
+- `notebooks/hybrid_time_series_forecasting.ipynb` – end-to-end workflow covering data generation, preprocessing, model training, and evaluation. The notebook also includes an experiment that sweeps the quantum circuit depth.
+- `reports/hybrid_forecasting_report.md` – concise report summarizing the experimental setup, modelling choices, insights, and recommended future work.
+
+## Getting Started
+1. Create and activate a Python 3.10 environment with internet access.
+2. Install dependencies (PyTorch, PennyLane, scikit-learn, matplotlib, pandas, numpy). The notebook begins with installation commands for convenience.
+3. Launch JupyterLab or Jupyter Notebook and open `notebooks/hybrid_time_series_forecasting.ipynb`.
+4. Run the cells sequentially to reproduce the baseline and hybrid model experiments and compare their performance.
+
+## Notes
+- The repository uses a synthetic dataset for reproducibility. You can swap in any real-world time series by modifying the data preparation cells in the notebook.
+- Due to the offline nature of the development environment, dependencies are not vendored in the repository. Ensure that required packages are available before executing the notebook.

--- a/notebooks/hybrid_time_series_forecasting.ipynb
+++ b/notebooks/hybrid_time_series_forecasting.ipynb
@@ -1,0 +1,427 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Hybrid Quantum-Classical Time Series Forecasting\n",
+        "\n",
+        "This notebook builds a hybrid quantum-classical model for time series forecasting on a synthetic dataset and compares it with a classical baseline.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 1. Setup\n",
+        "Install required libraries and configure the environment.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "!pip -q install pennylane torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cpu > /dev/null\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "import math\n",
+        "import random\n",
+        "from pathlib import Path\n",
+        "\n",
+        "import matplotlib.pyplot as plt\n",
+        "import numpy as np\n",
+        "import pandas as pd\n",
+        "import pennylane as qml\n",
+        "import torch\n",
+        "from sklearn.metrics import mean_absolute_error, mean_squared_error\n",
+        "from sklearn.preprocessing import MinMaxScaler\n",
+        "from torch import nn\n",
+        "from torch.utils.data import DataLoader, TensorDataset\n",
+        "\n",
+        "plt.style.use('seaborn-v0_8')\n",
+        "\n",
+        "torch.manual_seed(42)\n",
+        "np.random.seed(42)\n",
+        "random.seed(42)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 2. Data Preparation\n",
+        "Generate a synthetic time series and prepare training/test windows.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "# Generate a synthetic time series that combines trend, seasonal, and noise components\n",
+        "n_points = 1800\n",
+        "time = np.arange(n_points)\n",
+        "series = 0.05 * time + np.sin(0.2 * time) + 0.5 * np.sin(0.05 * time) + 0.3 * np.cos(0.15 * time)\n",
+        "noise = np.random.normal(scale=0.2, size=n_points)\n",
+        "series += noise\n",
+        "\n",
+        "series_df = pd.DataFrame({\"t\": time, \"value\": series})\n",
+        "series_df.head()\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "fig, ax = plt.subplots(figsize=(12, 4))\n",
+        "ax.plot(series_df[\"t\"], series_df[\"value\"], label=\"Synthetic series\")\n",
+        "ax.set_xlabel(\"Time step\")\n",
+        "ax.set_ylabel(\"Value\")\n",
+        "ax.set_title(\"Synthetic time series used for forecasting\")\n",
+        "ax.legend()\n",
+        "plt.show()\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "# Scaling\n",
+        "scaler = MinMaxScaler()\n",
+        "series_scaled = scaler.fit_transform(series_df[[\"value\"]]).flatten()\n",
+        "\n",
+        "# Windowing helper\n",
+        "def create_windows(data, window_size, horizon=1):\n",
+        "    X, y = [], []\n",
+        "    for i in range(len(data) - window_size - horizon + 1):\n",
+        "        X.append(data[i : i + window_size])\n",
+        "        y.append(data[i + window_size : i + window_size + horizon])\n",
+        "    return np.array(X), np.array(y)\n",
+        "\n",
+        "window_size = 32\n",
+        "horizon = 1\n",
+        "X, y = create_windows(series_scaled, window_size, horizon)\n",
+        "\n",
+        "split_idx = int(0.75 * len(X))\n",
+        "X_train, X_test = X[:split_idx], X[split_idx:]\n",
+        "y_train, y_test = y[:split_idx], y[split_idx:]\n",
+        "\n",
+        "X_train_tensor = torch.tensor(X_train, dtype=torch.float32).unsqueeze(-1)\n",
+        "X_test_tensor = torch.tensor(X_test, dtype=torch.float32).unsqueeze(-1)\n",
+        "y_train_tensor = torch.tensor(y_train, dtype=torch.float32)\n",
+        "y_test_tensor = torch.tensor(y_test, dtype=torch.float32)\n",
+        "\n",
+        "batch_size = 64\n",
+        "train_loader = DataLoader(TensorDataset(X_train_tensor, y_train_tensor), batch_size=batch_size, shuffle=True)\n",
+        "val_loader = DataLoader(TensorDataset(X_test_tensor, y_test_tensor), batch_size=batch_size)\n",
+        "\n",
+        "X_train_tensor.shape, y_train_tensor.shape\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 3. Classical Baseline (LSTM)\n",
+        "Train a purely classical LSTM baseline.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "class LSTMForecaster(nn.Module):\n",
+        "    def __init__(self, input_size=1, hidden_size=32, num_layers=1, dropout=0.1):\n",
+        "        super().__init__()\n",
+        "        self.lstm = nn.LSTM(input_size=input_size, hidden_size=hidden_size, num_layers=num_layers, batch_first=True, dropout=dropout if num_layers > 1 else 0.0)\n",
+        "        self.fc = nn.Sequential(\n",
+        "            nn.Linear(hidden_size, hidden_size),\n",
+        "            nn.ReLU(),\n",
+        "            nn.Linear(hidden_size, horizon)\n",
+        "        )\n",
+        "\n",
+        "    def forward(self, x):\n",
+        "        lstm_out, _ = self.lstm(x)\n",
+        "        last_hidden = lstm_out[:, -1, :]\n",
+        "        return self.fc(last_hidden)\n",
+        "\n",
+        "\n",
+        "def train_model(model, train_loader, val_loader, epochs=30, lr=1e-3):\n",
+        "    device = torch.device(\"cpu\")\n",
+        "    model.to(device)\n",
+        "    optimizer = torch.optim.Adam(model.parameters(), lr=lr)\n",
+        "    criterion = nn.MSELoss()\n",
+        "    history = {\"train_loss\": [], \"val_loss\": []}\n",
+        "\n",
+        "    for epoch in range(1, epochs + 1):\n",
+        "        model.train()\n",
+        "        train_losses = []\n",
+        "        for xb, yb in train_loader:\n",
+        "            xb, yb = xb.to(device), yb.to(device)\n",
+        "            optimizer.zero_grad()\n",
+        "            preds = model(xb)\n",
+        "            loss = criterion(preds, yb)\n",
+        "            loss.backward()\n",
+        "            optimizer.step()\n",
+        "            train_losses.append(loss.item())\n",
+        "\n",
+        "        model.eval()\n",
+        "        val_losses = []\n",
+        "        with torch.no_grad():\n",
+        "            for xb, yb in val_loader:\n",
+        "                xb, yb = xb.to(device), yb.to(device)\n",
+        "                preds = model(xb)\n",
+        "                loss = criterion(preds, yb)\n",
+        "                val_losses.append(loss.item())\n",
+        "\n",
+        "        history[\"train_loss\"].append(np.mean(train_losses))\n",
+        "        history[\"val_loss\"].append(np.mean(val_losses))\n",
+        "        if epoch % 5 == 0 or epoch == 1:\n",
+        "            print(f\"Epoch {epoch:02d} | Train Loss: {history['train_loss'][-1]:.4f} | Val Loss: {history['val_loss'][-1]:.4f}\")\n",
+        "\n",
+        "    return history\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "baseline_model = LSTMForecaster(hidden_size=32)\n",
+        "baseline_history = train_model(baseline_model, train_loader, val_loader, epochs=35, lr=5e-3)\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "def evaluate(model, X_tensor, y_true_tensor):\n",
+        "    model.eval()\n",
+        "    with torch.no_grad():\n",
+        "        preds = model(X_tensor).cpu().numpy().flatten()\n",
+        "    y_true = y_true_tensor.cpu().numpy().flatten()\n",
+        "    mse = mean_squared_error(y_true, preds)\n",
+        "    rmse = math.sqrt(mse)\n",
+        "    mae = mean_absolute_error(y_true, preds)\n",
+        "    return preds, {\"MSE\": mse, \"RMSE\": rmse, \"MAE\": mae}\n",
+        "\n",
+        "baseline_preds, baseline_metrics = evaluate(baseline_model, X_test_tensor, y_test_tensor)\n",
+        "baseline_metrics\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "# Plot baseline predictions vs actuals on the test set\n",
+        "actual = scaler.inverse_transform(y_test)\n",
+        "predicted = scaler.inverse_transform(baseline_preds.reshape(-1, 1))\n",
+        "\n",
+        "fig, ax = plt.subplots(figsize=(12, 4))\n",
+        "ax.plot(actual, label=\"Actual\", linewidth=2)\n",
+        "ax.plot(predicted, label=\"LSTM Baseline\", linestyle='--')\n",
+        "ax.set_title(\"Baseline LSTM Forecast vs Actual\")\n",
+        "ax.set_xlabel(\"Test time step\")\n",
+        "ax.set_ylabel(\"Value\")\n",
+        "ax.legend()\n",
+        "plt.show()\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 4. Hybrid Quantum-Classical Model\n",
+        "Build an LSTM combined with a variational quantum circuit layer implemented with PennyLane.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "class QuantumLSTMForecaster(nn.Module):\n",
+        "    def __init__(self, input_size=1, hidden_size=32, n_qubits=4, q_depth=2):\n",
+        "        super().__init__()\n",
+        "        self.hidden_size = hidden_size\n",
+        "        self.n_qubits = n_qubits\n",
+        "\n",
+        "        self.lstm = nn.LSTM(input_size=input_size, hidden_size=hidden_size, batch_first=True)\n",
+        "        self.to_qubits = nn.Linear(hidden_size, n_qubits)\n",
+        "\n",
+        "        dev = qml.device(\"default.qubit.torch\", wires=n_qubits)\n",
+        "\n",
+        "        @qml.qnode(dev, interface=\"torch\")\n",
+        "        def circuit(inputs, weights):\n",
+        "            qml.templates.AngleEmbedding(inputs, wires=range(n_qubits), rotation='Y')\n",
+        "            qml.templates.StronglyEntanglingLayers(weights, wires=range(n_qubits))\n",
+        "            return [qml.expval(qml.PauliZ(i)) for i in range(n_qubits)]\n",
+        "\n",
+        "        weight_shapes = {\"weights\": (q_depth, n_qubits, 3)}\n",
+        "        self.quantum_layer = qml.qnn.TorchLayer(circuit, weight_shapes)\n",
+        "        self.readout = nn.Sequential(\n",
+        "            nn.Linear(n_qubits, hidden_size),\n",
+        "            nn.ReLU(),\n",
+        "            nn.Linear(hidden_size, horizon)\n",
+        "        )\n",
+        "\n",
+        "    def forward(self, x):\n",
+        "        lstm_out, _ = self.lstm(x)\n",
+        "        last_hidden = lstm_out[:, -1, :]\n",
+        "        qubit_inputs = torch.tanh(self.to_qubits(last_hidden))\n",
+        "        quantum_out = self.quantum_layer(qubit_inputs)\n",
+        "        return self.readout(quantum_out)\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "quantum_model = QuantumLSTMForecaster(hidden_size=32, n_qubits=4, q_depth=2)\n",
+        "quantum_history = train_model(quantum_model, train_loader, val_loader, epochs=35, lr=5e-3)\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "quantum_preds, quantum_metrics = evaluate(quantum_model, X_test_tensor, y_test_tensor)\n",
+        "quantum_metrics\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "actual = scaler.inverse_transform(y_test)\n",
+        "quantum_predicted = scaler.inverse_transform(quantum_preds.reshape(-1, 1))\n",
+        "\n",
+        "fig, ax = plt.subplots(figsize=(12, 4))\n",
+        "ax.plot(actual, label=\"Actual\", linewidth=2)\n",
+        "ax.plot(quantum_predicted, label=\"Hybrid QNN\", linestyle='--')\n",
+        "ax.set_title(\"Hybrid Quantum-Classical Forecast vs Actual\")\n",
+        "ax.set_xlabel(\"Test time step\")\n",
+        "ax.set_ylabel(\"Value\")\n",
+        "ax.legend()\n",
+        "plt.show()\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 5. Circuit Depth Experiments\n",
+        "Evaluate different quantum circuit depths and compare metrics.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "results = []\n",
+        "for depth in [1, 2, 3]:\n",
+        "    print(f\"\\nTraining hybrid model with circuit depth = {depth}\")\n",
+        "    model = QuantumLSTMForecaster(hidden_size=32, n_qubits=4, q_depth=depth)\n",
+        "    train_model(model, train_loader, val_loader, epochs=25, lr=5e-3)\n",
+        "    _, metrics = evaluate(model, X_test_tensor, y_test_tensor)\n",
+        "    results.append({\"Circuit depth\": depth, **metrics})\n",
+        "\n",
+        "depth_results_df = pd.DataFrame(results)\n",
+        "depth_results_df\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 6. Comparison Summary\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "comparison_df = pd.DataFrame([\n",
+        "    {\"Model\": \"LSTM Baseline\", **baseline_metrics},\n",
+        "    {\"Model\": \"Hybrid QNN (depth=2)\", **quantum_metrics}\n",
+        "])\n",
+        "comparison_df\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "fig, ax = plt.subplots(figsize=(6, 4))\n",
+        "metrics_to_plot = [\"RMSE\", \"MAE\"]\n",
+        "width = 0.35\n",
+        "x = np.arange(len(metrics_to_plot))\n",
+        "\n",
+        "baseline_vals = [baseline_metrics[m] for m in metrics_to_plot]\n",
+        "quantum_vals = [quantum_metrics[m] for m in metrics_to_plot]\n",
+        "\n",
+        "ax.bar(x - width/2, baseline_vals, width, label=\"LSTM Baseline\")\n",
+        "ax.bar(x + width/2, quantum_vals, width, label=\"Hybrid QNN\")\n",
+        "ax.set_xticks(x)\n",
+        "ax.set_xticklabels(metrics_to_plot)\n",
+        "ax.set_ylabel(\"Error\")\n",
+        "ax.set_title(\"Error comparison\")\n",
+        "ax.legend()\n",
+        "plt.show()\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "The notebook above can be extended further by adjusting hyperparameters, experimenting with different quantum circuits, or changing the dataset.\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.10"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/reports/hybrid_forecasting_report.md
+++ b/reports/hybrid_forecasting_report.md
@@ -1,0 +1,42 @@
+# Hybrid Quantum-Classical Time Series Forecasting Report
+
+## Overview
+This report summarizes the development of a hybrid quantum-classical model for time series forecasting. The accompanying notebook (`notebooks/hybrid_time_series_forecasting.ipynb`) walks through data preparation, model construction, training workflows, and evaluation utilities that compare a classical LSTM baseline with a quantum-enhanced LSTM.
+
+## Dataset and Preprocessing
+- **Dataset**: A synthetic univariate series composed of linear trend, multiple sinusoidal components, and additive Gaussian noise (1,800 time steps).
+- **Scaling**: Min-max normalization to the range `[0, 1]` for stable optimization.
+- **Windowing**: Sliding windows of length 32 with a forecast horizon of one step to create supervised learning samples.
+- **Splits**: Chronological split with 75% for training and 25% for testing. PyTorch `DataLoader` objects handle batching and shuffling for the training subset.
+
+## Models
+### Classical Baseline
+- Single-layer LSTM with 32 hidden units and a feed-forward projection head.
+- Optimized via Adam (`lr=5e-3`) using mean squared error loss.
+
+### Hybrid Quantum-Classical Model
+- Shares the LSTM encoder backbone with the baseline.
+- Projects the final hidden state to four qubit rotation angles via a linear layer with `tanh` activation.
+- Employs a PennyLane variational circuit using `StronglyEntanglingLayers` across 4 qubits with configurable depth.
+- Quantum expectation values are mapped back to forecast space through a classical readout network.
+
+## Training and Evaluation
+- Utility functions in the notebook train models for a configurable number of epochs and capture loss curves.
+- Evaluation computes MSE, RMSE, and MAE on the held-out test set along with visualization of predictions versus ground truth.
+- Additional experiments sweep circuit depths (1–3 layers) to study trade-offs between model expressivity and generalization.
+
+## Key Insights and Observations
+- The hybrid approach is designed to investigate whether quantum feature transformations can reduce forecast error compared with the classical baseline.
+- Expectation: moderate circuit depths (e.g., depth=2) should balance performance and training stability; excessive depth may overfit or slow convergence.
+- Visualizations illustrate qualitative differences between forecast trajectories, enabling inspection of phase alignment and amplitude capture.
+
+## Challenges and Improvements
+- **Environment limitations**: The execution environment used to generate this report lacks direct internet access, preventing automatic installation of dependencies such as PyTorch and PennyLane. The notebook includes installation commands that should be executed in an environment with package access before running the experiments.
+- **Possible enhancements**:
+  - Explore alternative quantum encodings (e.g., amplitude encoding or data re-uploading techniques).
+  - Integrate classical regularization strategies (dropout, weight decay) to stabilize training.
+  - Evaluate on real-world datasets (e.g., energy demand, stock prices) to assess robustness.
+  - Extend comparisons with additional classical baselines (ARIMA, Transformer) for broader benchmarking.
+
+## Contribution of the Quantum Circuit
+Running the notebook in a fully provisioned environment allows direct comparison of forecast metrics to determine whether the quantum circuit yields measurable improvements. The provided framework streamlines experimentation so researchers can quantify the contribution of the variational circuit relative to the classical LSTM baseline.


### PR DESCRIPTION
## Summary
- add a Jupyter notebook that generates a synthetic time series, trains an LSTM baseline, and introduces a hybrid quantum-classical forecaster
- document the experimental setup and observations in a concise markdown report
- update the README with project overview and usage instructions

## Testing
- not run (dependencies unavailable in offline environment)


------
https://chatgpt.com/codex/tasks/task_b_68e51b4753ac833183f79c5f84c203f1